### PR TITLE
Add reminders about security best practices and redact secrets in logs

### DIFF
--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -14,6 +14,11 @@ Stripe.set_app_info(
   version: '0.0.1',
   url: 'https://github.com/stripe-samples/push-provisioning'
 )
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 
 set :port, 4242


### PR DESCRIPTION
## Summary

- Adds a comment before `STRIPE_SECRET_KEY` assignment in `server/ruby/server.rb` urging users not to put keys in code and pointing to https://docs.stripe.com/keys-best-practices.